### PR TITLE
Install kernel headers on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: c
 compiler: gcc
 dist: trusty
+addons:
+  apt:
+    packages:
+      - linux-libc-dev
 script:
   - autoreconf -fi
   - ./configure


### PR DESCRIPTION
This fixes the configure check for MDIO support.

Signed-off-by: Jan Luebbe <jlu@pengutronix.de>